### PR TITLE
clarify class names

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8,9 +8,9 @@ parameters:
 		-
 			message: "#^Access to an undefined property PhpParser\\\\Node\\\\Expr\\:\\:\\$name\\.$#"
 			count: 1
-			path: src/Tester/Visitor.php
+			path: src/Tester/PhpNodeVisitor.php
 
 		-
 			message: "#^Access to an undefined property PhpParser\\\\Node\\\\Expr\\|PhpParser\\\\Node\\\\Identifier\\:\\:\\$name\\.$#"
 			count: 1
-			path: src/Tester/Visitor.php
+			path: src/Tester/PhpNodeVisitor.php

--- a/src/Tester/PhpNodeVisitor.php
+++ b/src/Tester/PhpNodeVisitor.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * contains the Visitor class
+ * contains the PhpNodeVisitor class
  *
  * @category        Database Query Validator
  * @author          David Lienhard <david@lienhard.win>
@@ -22,7 +22,7 @@ use PhpParser\PrettyPrinter\Standard;
  * @author          David Lienhard <david@lienhard.win>
  * @copyright       David Lienhard
  */
-class Visitor extends NodeVisitorAbstract
+class PhpNodeVisitor extends NodeVisitorAbstract
 {
     /**
      * list of all the queries found

--- a/src/Tester/TestFile.php
+++ b/src/Tester/TestFile.php
@@ -6,6 +6,7 @@ namespace DavidLienhard\Database\QueryValidator\Tester;
 
 use DavidLienhard\Database\QueryValidator\DumpData\DumpData;
 use DavidLienhard\Database\QueryValidator\Output\OutputInterface;
+use DavidLienhard\Database\QueryValidator\Tester\PhpNodeVisitor;
 use DavidLienhard\Database\QueryValidator\Tester\TestFileInterface;
 use PhpMyAdmin\SqlParser\Lexer as SqlLexer;
 use PhpMyAdmin\SqlParser\Parser as SqlParser;
@@ -54,7 +55,7 @@ class TestFile implements TestFileInterface
         try {
             $parser = (new PhpParserFactory)->create(PhpParserFactory::PREFER_PHP7);
             $traverser = new PhpNodeTraverser;
-            $visitor = new Visitor;
+            $visitor = new PhpNodeVisitor;
             $traverser->addVisitor($visitor);
 
             $fileContent = \file_get_contents($this->file);

--- a/src/Tester/TestFile.php
+++ b/src/Tester/TestFile.php
@@ -7,12 +7,12 @@ namespace DavidLienhard\Database\QueryValidator\Tester;
 use DavidLienhard\Database\QueryValidator\DumpData\DumpData;
 use DavidLienhard\Database\QueryValidator\Output\OutputInterface;
 use DavidLienhard\Database\QueryValidator\Tester\TestFileInterface;
-use PhpMyAdmin\SqlParser\Lexer;
-use PhpMyAdmin\SqlParser\Parser;
+use PhpMyAdmin\SqlParser\Lexer as SqlLexer;
+use PhpMyAdmin\SqlParser\Parser as SqlParser;
 use PhpMyAdmin\SqlParser\Utils\Error as SqlParserError;
 use PhpParser\Error as PhpParserError;
-use PhpParser\NodeTraverser;
-use PhpParser\ParserFactory;
+use PhpParser\NodeTraverser as PhpNodeTraverser;
+use PhpParser\ParserFactory as PhpParserFactory;
 
 class TestFile implements TestFileInterface
 {
@@ -52,8 +52,8 @@ class TestFile implements TestFileInterface
     public function validate() : void
     {
         try {
-            $parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-            $traverser = new NodeTraverser;
+            $parser = (new PhpParserFactory)->create(PhpParserFactory::PREFER_PHP7);
+            $traverser = new PhpNodeTraverser;
             $visitor = new Visitor;
             $traverser->addVisitor($visitor);
 
@@ -271,8 +271,8 @@ class TestFile implements TestFileInterface
             throw new \Exception("unable to read query");
         }
 
-        $lexer = new Lexer($query, false);
-        $parser = new Parser($lexer->list);
+        $lexer = new SqlLexer($query, false);
+        $parser = new SqlParser($lexer->list);
         $errors = SqlParserError::get([$lexer, $parser]);
         if (count($errors) === 0) {
             return true;


### PR DESCRIPTION
use aliases to clarify differences between sql & php parser classes