### PR TITLE
move syntax test into separate class

### DIFF
--- a/src/Tester/TestFile.php
+++ b/src/Tester/TestFile.php
@@ -132,9 +132,7 @@ class TestFile implements TestFileInterface
 
             if (!$this->ignoresyntax) {
                 $testResult = $this->runTest(SyntaxTest::class, $query, "invalid syntax");
-                if ($testResult === false) {
-                    $hasError = true;
-                }
+                $hasError = $testResult === false ? true : $hasError;
             }
 
             $this->output->query(

--- a/src/Tester/TestFile.php
+++ b/src/Tester/TestFile.php
@@ -6,11 +6,10 @@ namespace DavidLienhard\Database\QueryValidator\Tester;
 
 use DavidLienhard\Database\QueryValidator\DumpData\DumpData;
 use DavidLienhard\Database\QueryValidator\Output\OutputInterface;
+use DavidLienhard\Database\QueryValidator\Queries\QueryInterface;
 use DavidLienhard\Database\QueryValidator\Tester\PhpNodeVisitor;
 use DavidLienhard\Database\QueryValidator\Tester\TestFileInterface;
-use PhpMyAdmin\SqlParser\Lexer as SqlLexer;
-use PhpMyAdmin\SqlParser\Parser as SqlParser;
-use PhpMyAdmin\SqlParser\Utils\Error as SqlParserError;
+use DavidLienhard\Database\QueryValidator\Tester\Tests\Syntax as SyntaxTest;
 use PhpParser\Error as PhpParserError;
 use PhpParser\NodeTraverser as PhpNodeTraverser;
 use PhpParser\ParserFactory as PhpParserFactory;
@@ -111,7 +110,6 @@ class TestFile implements TestFileInterface
      * @throws          \Exception                      if the file does not exist
      * @uses            self::addError()
      * @uses            self::checkPreparedStatement()
-     * @uses            self::checkMysqlSyntax()
      * @uses            self::$queryCount
      */
     public function validateQueries(string $file, array $queries) : void
@@ -132,14 +130,11 @@ class TestFile implements TestFileInterface
                 ) ? $hasError : true;
             }
 
-            if (!$this->ignoresyntax && self::checkMysqlSyntax($query->getQuery()) !== true) {
-                $this->addError(
-                    $query->getFilename(),
-                    $query->getLinenumber(),
-                    "invalid sql syntax"
-                );
-
-                $hasError = true;
+            if (!$this->ignoresyntax) {
+                $testResult = $this->runTest(SyntaxTest::class, $query, "invalid syntax");
+                if ($testResult === false) {
+                    $hasError = true;
+                }
             }
 
             $this->output->query(
@@ -252,38 +247,6 @@ class TestFile implements TestFileInterface
     }
 
     /**
-     * checks if the syntax of a query is valid
-     *
-     * @author          David Lienhard <github@lienhard.win>
-     * @copyright       David Lienhard
-     * @param           string          $query      query to analyze
-     * @return          bool|array                  true or a list of errors
-     * @uses            \PhpMyAdmin\SqlParser\Lexer
-     * @uses            \PhpMyAdmin\SqlParser\Parser
-     * @uses            \PhpMyAdmin\SqlParser\Utils\Error
-     */
-    public static function checkMysqlSyntax(string $query) : bool|array
-    {
-        $query = trim($query, " \t\n\r\0\x0B\"");
-
-        $from = [ "/\\\\n/", "/\?/" ];  // replace \n (as string) with newlines and questionmarks with 1 for validation
-        $to = [ "\n", 1 ];
-        $query = \preg_replace($from, $to, $query);
-
-        if ($query === null) {
-            throw new \Exception("unable to read query");
-        }
-
-        $lexer = new SqlLexer($query, false);
-        $parser = new SqlParser($lexer->list);
-        $errors = SqlParserError::get([$lexer, $parser]);
-        if (count($errors) === 0) {
-            return true;
-        }
-        return SqlParserError::format($errors);
-    }
-
-    /**
      * adds an error to the internal error list
      *
      * @author          David Lienhard <github@lienhard.win>
@@ -328,5 +291,24 @@ class TestFile implements TestFileInterface
     public function getErrors() : array
     {
         return $this->errors;
+    }
+
+    private function runTest(string $className, QueryInterface $query, string $errorPrefix = "") : bool
+    {
+        $tester = new $className($query, $this->dumpData);
+        $tester->validate();
+        $errors = $tester->getErrors();
+        $errorCount = $tester->getErrorcount();
+        unset($tester);
+
+        foreach ($errors as $error) {
+            $this->addError(
+                $query->getFilename(),
+                $query->getLinenumber(),
+                $errorPrefix." '".$error."'"
+            );
+        }
+
+        return $errorCount > 0;
     }
 }

--- a/src/Tester/Tests/Syntax.php
+++ b/src/Tester/Tests/Syntax.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DavidLienhard\Database\QueryValidator\Tester\Tests;
+
+use PhpMyAdmin\SqlParser\Lexer as SqlLexer;
+use PhpMyAdmin\SqlParser\Parser as SqlParser;
+use PhpMyAdmin\SqlParser\Utils\Error as SqlParserError;
+
+class Syntax extends TestAbstract
+{
+    /**
+     * starts the validation
+     *
+     * @author          David Lienhard <github@lienhard.win>
+     * @copyright       David Lienhard
+     */
+    public function validate() : bool
+    {
+        $query = $this->query->getQuery();
+        $query = trim($query, " \t\n\r\0\x0B\"");
+
+        // replace \n (as string) with newlines and questionmarks with 1 for validation
+        $from = [ "/\\\\n/", "/\?/" ];
+        $to = [ "\n", 1 ];
+        $query = \preg_replace($from, $to, $query);
+
+        if ($query === null) {
+            return false;
+        }
+
+        $lexer = new SqlLexer($query, false);
+        $parser = new SqlParser($lexer->list);
+        $errors = SqlParserError::get([$lexer, $parser]);
+
+        if (count($errors) === 0) {
+            return true;
+        }
+
+        $this->errors [] = SqlParserError::format($errors);
+
+        return false;
+    }
+}

--- a/src/Tester/Tests/TestAbstract.php
+++ b/src/Tester/Tests/TestAbstract.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DavidLienhard\Database\QueryValidator\Tester\Tests;
+
+use DavidLienhard\Database\QueryValidator\DumpData\DumpData;
+use DavidLienhard\Database\QueryValidator\Queries\QueryInterface;
+
+abstract class TestAbstract implements TestInterface
+{
+    /**
+     * list of errors that occurred validating the query
+     * array<string>
+     */
+    protected array $errors = [];
+
+    /**
+     * sets dependencies
+     *
+     * @author          David Lienhard <github@lienhard.win>
+     * @copyright       David Lienhard
+     * @param           QueryInterface  $query          query to validate
+     * @param           DumpData        $dumpData       data from the database-dump
+     */
+    public function __construct(
+        protected QueryInterface $query,
+        protected DumpData $dumpData
+    ) {
+    }
+
+    /**
+     * starts the validation
+     *
+     * @author          David Lienhard <github@lienhard.win>
+     * @copyright       David Lienhard
+     */
+    abstract public function validate() : bool;
+
+    /**
+     * returns the number of errors
+     *
+     * @author          David Lienhard <github@lienhard.win>
+     * @copyright       David Lienhard
+     */
+    public function getErrorcount() : int
+    {
+        return count($this->errors);
+    }
+
+    /**
+     * returns the list of errors
+     *
+     * @author          David Lienhard <github@lienhard.win>
+     * @copyright       David Lienhard
+     * @return          array<string>
+     */
+    public function getErrors() : array
+    {
+        return $this->errors;
+    }
+}

--- a/src/Tester/Tests/TestInterface.php
+++ b/src/Tester/Tests/TestInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DavidLienhard\Database\QueryValidator\Tester\Tests;
+
+use DavidLienhard\Database\QueryValidator\DumpData\DumpData;
+use DavidLienhard\Database\QueryValidator\Queries\QueryInterface;
+
+interface TestInterface
+{
+    /**
+     * sets dependencies
+     *
+     * @author          David Lienhard <github@lienhard.win>
+     * @copyright       David Lienhard
+     * @param           QueryInterface  $query          query to validate
+     * @param           DumpData        $dumpData       data from the database-dump
+     */
+    public function __construct(
+        QueryInterface $query,
+        DumpData $dumpData
+    );
+
+    /**
+     * starts the validation
+     *
+     * @author          David Lienhard <github@lienhard.win>
+     * @copyright       David Lienhard
+     */
+    public function validate() : bool;
+
+    /**
+     * returns the number of errors
+     *
+     * @author          David Lienhard <github@lienhard.win>
+     * @copyright       David Lienhard
+     */
+    public function getErrorcount() : int;
+
+    /**
+     * returns the list of errors
+     *
+     * @author          David Lienhard <github@lienhard.win>
+     * @copyright       David Lienhard
+     */
+    public function getErrors() : array;
+}

--- a/tests/Tester/Tests/SyntaxTest.php
+++ b/tests/Tester/Tests/SyntaxTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DavidLienhard\Database\QueryValidator\Tests\Queries;
+
+use DavidLienhard\Database\QueryValidator\DumpData\DumpData;
+use DavidLienhard\Database\QueryValidator\Queries\Query;
+use DavidLienhard\Database\QueryValidator\Tester\Tests\Syntax as SyntaxTest;
+use DavidLienhard\Database\QueryValidator\Tester\Tests\TestInterface;
+use PHPUnit\Framework\TestCase;
+
+class SyntayTest extends TestCase
+{
+    /**
+     * @covers DavidLienhard\Database\QueryValidator\Tester\Tests\Syntax
+     * @test
+     */
+    public function testCanBeCreated(): void
+    {
+        $query = new Query("SELECT * FROM `table`", [], "testfile.php", 1);
+        $dump = new DumpData;
+        $syntax = new SyntaxTest($query, $dump);
+
+        $this->assertInstanceOf(SyntaxTest::class, $syntax);
+        $this->assertInstanceOf(TestInterface::class, $syntax);
+    }
+
+
+    /**
+     * @covers DavidLienhard\Database\QueryValidator\Tester\Tests\Syntax
+     * @test
+     */
+    public function testReturnTrueForValidQuery(): void
+    {
+        $query = new Query("SELECT * FROM `table`", [], "testfile.php", 1);
+        $dump = new DumpData;
+        $syntax = new SyntaxTest($query, $dump);
+
+        $this->assertTrue($syntax->validate());
+        $this->assertEquals(0, $syntax->getErrorcount());
+    }
+
+
+    /**
+     * @covers DavidLienhard\Database\QueryValidator\Tester\Tests\Syntax
+     * @test
+     */
+    public function testReturnFalseForInvalidQuery(): void
+    {
+        $query = new Query("invalidquery", [], "testfile.php", 1);
+        $dump = new DumpData;
+        $syntax = new SyntaxTest($query, $dump);
+
+        $this->assertFalse($syntax->validate());
+        $this->assertEquals(1, $syntax->getErrorcount());
+    }
+}


### PR DESCRIPTION
create new class to check the syntax of a query instead of doing this in the `TestFile` class
 - create new `TestInterface` for all future tests
 - create new `TestAbstract` for all future tests
 - create new `Syntax` class
 - update `TestFile` class
 - add unit tests for `Syntax` class
 - add new method to `TestFile` to run tests