### PR TITLE
move isPrepared to query

### DIFF
--- a/src/Queries/Query.php
+++ b/src/Queries/Query.php
@@ -83,4 +83,15 @@ class Query implements QueryInterface
     {
         return $this->linenumber;
     }
+
+    /**
+     * returns whether this query is prepared or not
+     *
+     * @author          David Lienhard <github@lienhard.win>
+     * @copyright       David Lienhard
+     */
+    public function isPrepared() : bool
+    {
+        return count($this->parameters) > 0;
+    }
 }

--- a/src/Queries/QueryInterface.php
+++ b/src/Queries/QueryInterface.php
@@ -68,4 +68,12 @@ interface QueryInterface
      * @copyright       David Lienhard
      */
     public function getLinenumber() : int;
+
+    /**
+     * returns whether this query is prepared or not
+     *
+     * @author          David Lienhard <github@lienhard.win>
+     * @copyright       David Lienhard
+     */
+    public function isPrepared() : bool;
 }

--- a/src/Tester/TestFile.php
+++ b/src/Tester/TestFile.php
@@ -116,9 +116,8 @@ class TestFile implements TestFileInterface
     {
         foreach ($queries as $query) {
             $hasError = false;
-            $isPrepared = count($query->getParameters()) > 0;
 
-            if ($isPrepared) {
+            if ($query->isPrepared()) {
                 $queryString = $query->getQuery();
                 $parameters = $query->getParameters();
 


### PR DESCRIPTION
add new `isPrepared()` public method to `Query` class & interface
tells whether the query is a prepared statement or not