### PR TITLE
fix wrong result with invalid parameter

### DIFF
--- a/src/Tester/Tests/Parameters.php
+++ b/src/Tester/Tests/Parameters.php
@@ -40,6 +40,7 @@ class Parameters extends TestAbstract
             } else {
                 $types .= "-";
                 $this->errors[] = "parameter '".$parameterCount."' is invalid";
+                $isValid = false;
             }
         }
 


### PR DESCRIPTION
parameter check needs to return `false` if a parameter is invalid