### PR TITLE
fix bug in syntax errors

### DIFF
--- a/src/Tester/Tests/Syntax.php
+++ b/src/Tester/Tests/Syntax.php
@@ -38,7 +38,8 @@ class Syntax extends TestAbstract
             return true;
         }
 
-        $this->errors [] = SqlParserError::format($errors);
+        $errors = SqlParserError::format($errors);
+        $this->errors = array_merge($this->errors, $errors);
 
         return false;
     }


### PR DESCRIPTION
`SqlParserError` returns an array. so the result has be be merged to the currect errors