### PR TITLE
fix issue with parameter recognition

### DIFF
--- a/src/Tester/PhpNodeVisitor.php
+++ b/src/Tester/PhpNodeVisitor.php
@@ -69,6 +69,11 @@ class PhpNodeVisitor extends NodeVisitorAbstract
         unset($queryContent[0]);
         $parameters = count($queryContent) > 0 ? $queryContent : [];
 
+        // format query (string slashes & convert newlines)
+        $query = trim($query, "\"'");
+        $query = str_replace("\\n", "\n", $query);
+
+        // add new query
         $this->queries[] = new Query(
             $query,
             $parameters,


### PR DESCRIPTION
make sure that the query is readable in the `Query` object
 - strip leading & trailing slashes
 - convert `\n` to newlines