### PR TITLE
rename SyntaxTest class

### DIFF
--- a/tests/Tester/Tests/SyntaxTest.php
+++ b/tests/Tester/Tests/SyntaxTest.php
@@ -10,7 +10,7 @@ use DavidLienhard\Database\QueryValidator\Tester\Tests\Syntax as SyntaxTest;
 use DavidLienhard\Database\QueryValidator\Tester\Tests\TestInterface;
 use PHPUnit\Framework\TestCase;
 
-class SyntayTest extends TestCase
+class SyntaxTestCase extends TestCase
 {
     /**
      * @covers DavidLienhard\Database\QueryValidator\Tester\Tests\Syntax


### PR DESCRIPTION
fix typo in class-name and rename to `SyntaxTestCase` to prevent name-clash with Syntax Tester class