### PR TITLE
add new method to return all colums for table

### DIFF
--- a/src/DumpData/DumpData.php
+++ b/src/DumpData/DumpData.php
@@ -77,4 +77,17 @@ class DumpData
     {
         return $this->withoutTable[$columnName] ?? null;
     }
+
+    /**
+     * returns the data-type of a column without a known table
+     *
+     * @author          David Lienhard <github@lienhard.win>
+     * @copyright       David Lienhard
+     * @param           string          $tableName      name of the table
+     * @return          array<\DavidLienhard\Database\QueryValidator\DumpData\ColumnInterface>|null
+     */
+    public function getColumsForTable(string $tableName) : array|null
+    {
+        return $this->withTable[$tableName] ?? null;
+    }
 }

--- a/tests/DumpData/DumpDataTest.php
+++ b/tests/DumpData/DumpDataTest.php
@@ -47,4 +47,24 @@ class DumpDataTest extends TestCase
         $this->assertEquals("s", $dump->getWithoutTable("userDescription")->getType());
         $this->assertEquals("i", $dump->getWithoutTable("userPermissions")->getType());
     }
+
+
+    /**
+     * @covers DavidLienhard\Database\QueryValidator\DumpData\DumpData
+     * @test
+     */
+    public function testCanGetAlColumsForTable(): void
+    {
+        $dumpData = [
+            "userID"          => new Column("user", "userID", "i", false, false),
+            "userName"        => new Column("user", "userName", "s", false, false),
+            "userDescription" => new Column("user", "userDescription", "s", false, true),
+            "userPermissions" => new Column("user", "userPermissions", "i", false, false)
+        ];
+
+        $dump = new DumpData(array_values($dumpData));
+
+        $this->assertEquals($dumpData, $dump->getColumsForTable("user"));
+        $this->assertNull($dump->getColumsForTable("doesnotexist"));
+    }
 }


### PR DESCRIPTION
add new method `getColumsForTable()` that returns all saved colums for the given table or `null` if no colums exist