### PR TITLE
add StrictInserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The following configuration options are possible:
  - **`dumpfile`** (`string`): path to a mysql dump file to use for type-checks
  - **`parameters`** (`object`):
    - `ignoresyntax` (`bool`): whether or not to ignore syntax-errors in the queries
+   - `strictinserts` (`bool`): checks if inserts contains all text-colums of table that are set to not null
 
 All paths are relative to the path of the configuration file. If no configuration file can be found all the files in your currect folder will be scanned.
 
@@ -23,7 +24,8 @@ All paths are relative to the path of the configuration file. If no configuratio
     ],
     "dumpfile": "dump.sql",
     "parameters": {
-        "ignoresyntax": false
+        "ignoresyntax": false,
+        "strictinserts": false
     }
 }
 ```

--- a/src/Tester/TestFile.php
+++ b/src/Tester/TestFile.php
@@ -11,6 +11,7 @@ use DavidLienhard\Database\QueryValidator\Queries\QueryInterface;
 use DavidLienhard\Database\QueryValidator\Tester\PhpNodeVisitor;
 use DavidLienhard\Database\QueryValidator\Tester\TestFileInterface;
 use DavidLienhard\Database\QueryValidator\Tester\Tests\Parameters as ParametersTest;
+use DavidLienhard\Database\QueryValidator\Tester\Tests\StrictInserts as StrictInsertsTest;
 use DavidLienhard\Database\QueryValidator\Tester\Tests\Syntax as SyntaxTest;
 use PhpParser\Error as PhpParserError;
 use PhpParser\NodeTraverser as PhpNodeTraverser;
@@ -138,6 +139,18 @@ class TestFile implements TestFileInterface
 
             if (!$ignoresyntax) {
                 $testResult = $this->runTest(SyntaxTest::class, $query, "invalid syntax");
+                $hasError = $testResult === false ? true : $hasError;
+            }
+
+
+            try {
+                $strictinserts = (bool) $this->config->get("parameters", "strictinserts");
+            } catch (\Exception $e) {
+                $strictinserts = false;
+            }
+
+            if (!$strictinserts) {
+                $testResult = $this->runTest(StrictInsertsTest::class, $query);
                 $hasError = $testResult === false ? true : $hasError;
             }
 

--- a/src/Tester/Tests/StrictInserts.php
+++ b/src/Tester/Tests/StrictInserts.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DavidLienhard\Database\QueryValidator\Tester\Tests;
+
+use DavidLienhard\Database\QueryValidator\Queries\Query;
+
+class StrictInserts extends TestAbstract
+{
+    /**
+     * starts the validation
+     *
+     * @author          David Lienhard <github@lienhard.win>
+     * @copyright       David Lienhard
+     */
+    public function validate() : bool
+    {
+        if ($this->query->getType() !== Query::TYPE_INSERT) {
+            return true;
+        }
+
+        // get table name
+        $query = $this->query->getQuery();
+        $query = \preg_replace("/\\n/", " ", $query);
+
+        if ($query === null) {
+            $this->errors[] = "unable to remove newlines";
+            return false;
+        }
+
+        $result = \preg_match("/^INSERT INTO([ ]+)`([A-z0-9\-\_]+)`/mi", trim($query), $matches);
+
+        if ($result === false || $result === 0) {
+            $this->errors[] = "tablename could not be found in query";
+            return false;
+        }
+
+        $tableName = $matches[2];
+
+        // get all colums from table
+        $columns = $this->dumpData->getColumsForTable($tableName);
+
+        if ($columns === null) {
+            $this->errors[] = "no colums for table '".$tableName."' found in dump";
+            return false;
+        }
+
+        // get names of colums the must be in insert
+        // text-colums that are not nullable
+        $requiredColumns = array_filter(
+            $columns,
+            fn ($c) => $c->isText() && !$c->isNull()
+        );
+
+        unset($matches);
+        $result = \preg_match_all("/`([A-z0-9\-\_]+)`( |)=( |)/", trim($query), $matches);
+
+        if ($result === false || $result === 0) {
+            $this->errors[] = "could not find colums in current query";
+            return false;
+        }
+
+        $columnsInQuery = $matches[1] ?? [];
+
+        $isValid = true;
+        foreach ($requiredColumns as $requiredColumn) {
+            if (!in_array($requiredColumn->getName(), $columnsInQuery, true)) {
+                $this->errors[] = "column '".$requiredColumn->getName()."' is missing in insert";
+                $isValid = false;
+            }
+        }
+
+        return $isValid;
+    }
+}

--- a/tests/Tester/Tests/StrictInsertsTest.php
+++ b/tests/Tester/Tests/StrictInsertsTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DavidLienhard\Database\QueryValidator\Tests\Queries;
+
+use DavidLienhard\Database\QueryValidator\DumpData\Column;
+use DavidLienhard\Database\QueryValidator\DumpData\DumpData;
+use DavidLienhard\Database\QueryValidator\Queries\Query;
+use DavidLienhard\Database\QueryValidator\Tester\Tests\StrictInserts as StrictInsertsTest;
+use DavidLienhard\Database\QueryValidator\Tester\Tests\TestInterface;
+use PHPUnit\Framework\TestCase;
+
+class StrictInsertsTestCase extends TestCase
+{
+    /**
+     * @covers DavidLienhard\Database\QueryValidator\Tester\Tests\StrictInserts
+     * @test
+     */
+    public function testCanBeCreated(): void
+    {
+        $query = new Query("SELECT * FROM `table`", [], "testfile.php", 1);
+        $dump = new DumpData;
+        $inserts = new StrictInsertsTest($query, $dump);
+
+        $this->assertInstanceOf(StrictInsertsTest::class, $inserts);
+        $this->assertInstanceOf(TestInterface::class, $inserts);
+    }
+
+    /**
+     * @covers DavidLienhard\Database\QueryValidator\Tester\Tests\StrictInserts
+     * @test
+     */
+    public function testNonInsertQueriesReturnTrue(): void
+    {
+        $query = new Query("SELECT * FROM `table`", [], "testfile.php", 1);
+        $dump = new DumpData;
+        $inserts = new StrictInsertsTest($query, $dump);
+
+        $this->assertTrue($inserts->validate());
+        $this->assertEquals(0, $inserts->getErrorcount());
+    }
+
+    /**
+     * @covers DavidLienhard\Database\QueryValidator\Tester\Tests\StrictInserts
+     * @test
+     */
+    public function testInsertWithoutTablenameReturnsFalse(): void
+    {
+        $query = new Query("INSERT INTO SET `userName` = ''", [], "testfile.php", 1);
+        $dump = new DumpData;
+        $inserts = new StrictInsertsTest($query, $dump);
+
+        $this->assertFalse($inserts->validate());
+        $this->assertEquals(1, $inserts->getErrorcount());
+
+        $this->assertEquals(
+            [ "tablename could not be found in query" ],
+            $inserts->getErrors()
+        );
+    }
+
+    /**
+     * @covers DavidLienhard\Database\QueryValidator\Tester\Tests\StrictInserts
+     * @test
+     */
+    public function testReturnFalseForTableNotInDump(): void
+    {
+        $query = new Query("INSERT INTO `user` SET `userName` = ''", [], "testfile.php", 1);
+        $dump = new DumpData;
+        $inserts = new StrictInsertsTest($query, $dump);
+
+        $this->assertFalse($inserts->validate());
+        $this->assertEquals(1, $inserts->getErrorcount());
+
+        $this->assertEquals(
+            [ "no colums for table 'user' found in dump" ],
+            $inserts->getErrors()
+        );
+    }
+
+    /**
+     * @covers DavidLienhard\Database\QueryValidator\Tester\Tests\StrictInserts
+     * @test
+     */
+    public function testReturnFalseForQueryWithoutColums(): void
+    {
+        $query = new Query("INSERT INTO `user`", [], "testfile.php", 1);
+        $dump = new DumpData(
+            [
+                new Column("user", "userName", "s", false, false)
+            ]
+        );
+        $inserts = new StrictInsertsTest($query, $dump);
+
+        $this->assertFalse($inserts->validate());
+        $this->assertEquals(1, $inserts->getErrorcount());
+
+        $this->assertEquals(
+            [ "could not find colums in current query" ],
+            $inserts->getErrors()
+        );
+    }
+
+
+    /**
+     * @covers DavidLienhard\Database\QueryValidator\Tester\Tests\StrictInserts
+     * @test
+     */
+    public function testReturnTrueForValidQuery(): void
+    {
+        $query = new Query(
+            "INSERT INTO
+                `user`
+            SET
+                `userName` = ?",
+            [
+                "new DBParam(\"s\", \"test\")"
+            ],
+            "testfile.php",
+            1
+        );
+
+        $dump = new DumpData(
+            [
+                new Column("user", "userName", "s", false, false)
+            ]
+        );
+
+        $inserts = new StrictInsertsTest($query, $dump);
+
+        $this->assertTrue($inserts->validate());
+        $this->assertEquals(0, $inserts->getErrorcount());
+    }
+
+
+    /**
+     * @covers DavidLienhard\Database\QueryValidator\Tester\Tests\StrictInserts
+     * @test
+     */
+    public function testReturnFalseForInvalidQuery(): void
+    {
+        $query = new Query(
+            "INSERT INTO
+                `user`
+            SET
+                `userName` = ?",
+            [
+                "new DBParam(\"s\", \"test\")"
+            ],
+            "testfile.php",
+            1
+        );
+
+        $dump = new DumpData(
+            [
+                new Column("user", "userName", "s", false, false),
+                new Column("user", "userDescription1", "s", false, true),
+                new Column("user", "userDescription2", "s", true, true)
+            ]
+        );
+
+        $inserts = new StrictInsertsTest($query, $dump);
+
+        $this->assertFalse($inserts->validate());
+        $this->assertEquals(1, $inserts->getErrorcount());
+
+        $this->assertEquals(
+            [ "column 'userDescription1' is missing in insert" ],
+            $inserts->getErrors()
+        );
+    }
+}


### PR DESCRIPTION
check insert queries
text-colums cannot have a defualt value in mysql. so if they are set to `NOT NULL` the need to be in a insert query for that table
so we check all the colums inside each insert query agains the text-colums in the DumpData