### PR TITLE
ignore missing table-names

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The following configuration options are possible:
  - **`parameters`** (`object`):
    - `ignoresyntax` (`bool`): whether or not to ignore syntax-errors in the queries
    - `strictinserts` (`bool`): checks if inserts contains all text-colums of table that are set to not null
+   - `strictinsertsignoremissingtablenames` (`bool`): whether to ignore queries where the tablename could not be extracted on strict imports
 
 All paths are relative to the path of the configuration file. If no configuration file can be found all the files in your currect folder will be scanned.
 

--- a/src/Tester/TestFile.php
+++ b/src/Tester/TestFile.php
@@ -136,7 +136,10 @@ class TestFile implements TestFileInterface
             }
 
             if ($this->getConfigParameter("strictinserts")) {
-                $testResult = $this->runTest(StrictInsertsTest::class, $query);
+                $options = [
+                    "ignoreMissingTablenames" => $this->getConfigParameter("strictinsertsignoremissingtablenames")
+                ];
+                $testResult = $this->runTest(StrictInsertsTest::class, $query, "", $options);
                 $hasError = $testResult === false ? true : $hasError;
             }
 
@@ -197,9 +200,9 @@ class TestFile implements TestFileInterface
         return $this->errors;
     }
 
-    private function runTest(string $className, QueryInterface $query, string $errorPrefix = "") : bool
+    private function runTest(string $className, QueryInterface $query, string $errorPrefix = "", array $options = []) : bool
     {
-        $tester = new $className($query, $this->dumpData);
+        $tester = new $className($query, $this->dumpData, $options);
         $result = $tester->validate();
         $errors = $tester->getErrors();
         $errorCount = $tester->getErrorcount();

--- a/src/Tester/Tests/StrictInserts.php
+++ b/src/Tester/Tests/StrictInserts.php
@@ -32,7 +32,7 @@ class StrictInserts extends TestAbstract
         $result = \preg_match("/^INSERT INTO([ ]+)`([A-z0-9\-\_]+)`/mi", trim($query), $matches);
 
         if ($result === false || $result === 0) {
-            if (($this->options['strictinsertsignoremissingtablenames'] ?? false) === true) {
+            if (($this->options['ignoreMissingTablenames'] ?? false) === true) {
                 return true;
             }
 

--- a/src/Tester/Tests/StrictInserts.php
+++ b/src/Tester/Tests/StrictInserts.php
@@ -32,6 +32,10 @@ class StrictInserts extends TestAbstract
         $result = \preg_match("/^INSERT INTO([ ]+)`([A-z0-9\-\_]+)`/mi", trim($query), $matches);
 
         if ($result === false || $result === 0) {
+            if (($this->options['strictinsertsignoremissingtablenames'] ?? false) === true) {
+                return true;
+            }
+
             $this->errors[] = "tablename could not be found in query";
             return false;
         }

--- a/src/Tester/Tests/TestAbstract.php
+++ b/src/Tester/Tests/TestAbstract.php
@@ -25,7 +25,8 @@ abstract class TestAbstract implements TestInterface
      */
     public function __construct(
         protected QueryInterface $query,
-        protected DumpData $dumpData
+        protected DumpData $dumpData,
+        protected array $options = []
     ) {
     }
 

--- a/src/Tester/Tests/TestAbstract.php
+++ b/src/Tester/Tests/TestAbstract.php
@@ -22,6 +22,7 @@ abstract class TestAbstract implements TestInterface
      * @copyright       David Lienhard
      * @param           QueryInterface  $query          query to validate
      * @param           DumpData        $dumpData       data from the database-dump
+     * @param           array           $options        optional options to pass to the test
      */
     public function __construct(
         protected QueryInterface $query,

--- a/src/Tester/Tests/TestInterface.php
+++ b/src/Tester/Tests/TestInterface.php
@@ -19,7 +19,8 @@ interface TestInterface
      */
     public function __construct(
         QueryInterface $query,
-        DumpData $dumpData
+        DumpData $dumpData,
+        array $options = []
     );
 
     /**

--- a/src/Tester/Tests/TestInterface.php
+++ b/src/Tester/Tests/TestInterface.php
@@ -16,6 +16,7 @@ interface TestInterface
      * @copyright       David Lienhard
      * @param           QueryInterface  $query          query to validate
      * @param           DumpData        $dumpData       data from the database-dump
+     * @param           array           $options        optional options to pass to the test
      */
     public function __construct(
         QueryInterface $query,

--- a/tests/Tester/Tests/StrictInsertsTest.php
+++ b/tests/Tester/Tests/StrictInsertsTest.php
@@ -64,6 +64,20 @@ class StrictInsertsTestCase extends TestCase
      * @covers DavidLienhard\Database\QueryValidator\Tester\Tests\StrictInserts
      * @test
      */
+    public function testCanIgnoreInsertWithoutTablename(): void
+    {
+        $query = new Query("INSERT INTO SET `userName` = ''", [], "testfile.php", 1);
+        $dump = new DumpData;
+        $inserts = new StrictInsertsTest($query, $dump, [ "strictinsertsignoremissingtablenames" => true ]);
+
+        $this->assertTrue($inserts->validate());
+        $this->assertEquals(0, $inserts->getErrorcount());
+    }
+
+    /**
+     * @covers DavidLienhard\Database\QueryValidator\Tester\Tests\StrictInserts
+     * @test
+     */
     public function testReturnFalseForTableNotInDump(): void
     {
         $query = new Query("INSERT INTO `user` SET `userName` = ''", [], "testfile.php", 1);

--- a/tests/Tester/Tests/StrictInsertsTest.php
+++ b/tests/Tester/Tests/StrictInsertsTest.php
@@ -68,7 +68,7 @@ class StrictInsertsTestCase extends TestCase
     {
         $query = new Query("INSERT INTO SET `userName` = ''", [], "testfile.php", 1);
         $dump = new DumpData;
-        $inserts = new StrictInsertsTest($query, $dump, [ "strictinsertsignoremissingtablenames" => true ]);
+        $inserts = new StrictInsertsTest($query, $dump, [ "ignoreMissingTablenames" => true ]);
 
         $this->assertTrue($inserts->validate());
         $this->assertEquals(0, $inserts->getErrorcount());


### PR DESCRIPTION
add possibility to ignore missing table-names in strict inserts
this may happen if the table-name could not be recognized as it may be a variable or a function
 - add possibility to add options to tester classes
 - add new option named `strictinsertsignoremissingtablenames` to ignore missing table names
 - add tests