### PR TITLE
remove getConfigFolder folder

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -26,9 +26,8 @@ class Config implements ConfigInterface
      * @author          David Lienhard <github@lienhard.win>
      * @copyright       David Lienhard
      * @param           array           $config         configuration data to add
-     * @param           string          $configFile     path to the configuration file
      */
-    public function __construct(private array $config, private string $configFile)
+    public function __construct(private array $config)
     {
     }
 
@@ -51,16 +50,5 @@ class Config implements ConfigInterface
         }
 
         return $data;
-    }
-
-    /**
-     * returns the path to the folder containing the config file
-     *
-     * @author          David Lienhard <github@lienhard.win>
-     * @copyright       David Lienhard
-     */
-    public function getConfigFolder() : string
-    {
-        return dirname($this->configFile);
     }
 }

--- a/src/Config/ConfigInterface.php
+++ b/src/Config/ConfigInterface.php
@@ -24,9 +24,8 @@ interface ConfigInterface
      * @author          David Lienhard <github@lienhard.win>
      * @copyright       David Lienhard
      * @param           array           $config         configuration data to add
-     * @param           string          $configFile     path to the configuration file
      */
-    public function __construct(array $config, string $configFile);
+    public function __construct(array $config);
 
     /**
      * gets a configuration entry from the object
@@ -36,12 +35,4 @@ interface ConfigInterface
      * @param           string          $keys           keys to find the config entry
      */
     public function get(string ...$keys) : mixed;
-
-    /**
-     * returns the path to the folder containing the config file
-     *
-     * @author          David Lienhard <github@lienhard.win>
-     * @copyright       David Lienhard
-     */
-    public function getConfigFolder() : string;
 }

--- a/src/Config/Factory.php
+++ b/src/Config/Factory.php
@@ -52,7 +52,7 @@ class Factory
             );
         }
 
-        $config = self::addFromArguments($data, $file);
+        $config = self::addFromArguments($data);
 
         return $config;
     }
@@ -64,9 +64,8 @@ class Factory
      * @author          David Lienhard <github@lienhard.win>
      * @copyright       David Lienhard
      * @param           array           $data           data to create the Config instance with
-     * @param           string          $file           name of the configuration file
      */
-    private static function addFromArguments(array $data, string $file) : ConfigInterface
+    private static function addFromArguments(array $data) : ConfigInterface
     {
         $arguments = $_SERVER['argv'] ?? [];
 
@@ -74,7 +73,7 @@ class Factory
             $data['parameters']['fromstdin'] = true;
         }
 
-        return new Config($data, $file);
+        return new Config($data);
     }
 
 

--- a/src/QueryValidator.php
+++ b/src/QueryValidator.php
@@ -63,7 +63,7 @@ class QueryValidator
 
         $scanner->scan(
             $paths,
-            $config->getConfigFolder(),
+            dirname(__DIR__, 4),
             $exclusions
         );
 

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -16,7 +16,7 @@ class ConfigTestCase extends TestCase
      */
     public function testCanBeCreated(): void
     {
-        $config = new Config([], dirname(__DIR__)."assets/Config/dummy.json");
+        $config = new Config([]);
 
         $this->assertInstanceOf(Config::class, $config);
         $this->assertInstanceOf(ConfigInterface::class, $config);
@@ -27,21 +27,10 @@ class ConfigTestCase extends TestCase
      * @covers DavidLienhard\Database\QueryValidator\Config\Config
      * @test
      */
-    public function testCannotBeCreatedWithoutFile(): void
+    public function testCannotBeCreatedWithoutData(): void
     {
         $this->expectException(\ArgumentCountError::class);
-        new Config([]);
-    }
-
-
-    /**
-     * @covers DavidLienhard\Database\QueryValidator\Config\Config
-     * @test
-     */
-    public function testCannotBeCreatedWithoutDataAndFile(): void
-    {
-        $this->expectException(\ArgumentCountError::class);
-        new Config([]);
+        new Config;
     }
 
 
@@ -62,7 +51,7 @@ class ConfigTestCase extends TestCase
             ],
             "bool" => true,
             "null" => null
-        ], dirname(__DIR__)."assets/Config/dummy.json");
+        ]);
 
         $this->assertEquals("testfile", $config->get("file"));
 
@@ -90,21 +79,9 @@ class ConfigTestCase extends TestCase
      */
     public function testInexistentKeyReturnsNull(): void
     {
-        $config = new Config([], dirname(__DIR__)."assets/Config/dummy.json");
+        $config = new Config([]);
 
         $this->assertEquals(null, $config->get("file"));
         $this->assertEquals(null, $config->get("parameters", "file"));
-    }
-
-
-    /**
-     * @covers DavidLienhard\Database\QueryValidator\Config\Config
-     * @test
-     */
-    public function testCanGetConfigFolder(): void
-    {
-        $config = new Config([], dirname(__DIR__)."assets/Config/dummy.json");
-
-        $this->assertEquals(dirname(__DIR__)."assets/Config", $config->getConfigFolder());
     }
 }


### PR DESCRIPTION
remove `getConfigFolder` method from `Config` class
this mehtod has only been used to determine the root folder of the project