### PR TITLE
fix bug in query output

### DIFF
--- a/src/Output/Standard.php
+++ b/src/Output/Standard.php
@@ -29,7 +29,7 @@ class Standard implements OutputInterface
      */
     public function query(string $filename, int $line, bool $result) : void
     {
-        echo $this->queryCount % 80 === 0 ? PHP_EOL : "";
+        echo $this->queryCount % 80 === 0 && $this->queryCount !== 0 ? PHP_EOL : "";
         $this->queryCount++;
 
         echo $result ? "." : "x";


### PR DESCRIPTION
do not print newline before first query