### PR TITLE
fix bug with exclusions

### DIFF
--- a/src/Scanner/StdinScanner.php
+++ b/src/Scanner/StdinScanner.php
@@ -69,7 +69,7 @@ class StdinScanner implements ScannerInterface
                 $absolutePath = Path::makeAbsolute($filename, $absoluteFolder);
                 $absoluteExclusion = Path::makeAbsolute($exclusion, $absoluteFolder);
                 if (Glob::match($absolutePath, $absoluteExclusion)) {
-                    continue;
+                    continue(2);
                 }
             }
 


### PR DESCRIPTION
fix bug in `StdinScanner` not respecting exclusions
`continue` has not only to exit the exclusions loop, but also the files loop