### PR TITLE
convert all exception codes to int

### DIFF
--- a/src/Config/Factory.php
+++ b/src/Config/Factory.php
@@ -52,7 +52,7 @@ class Factory
         } catch (\Exception $e) {
             throw new ConfigException(
                 "unable to decode json data",
-                $e->getCode(),
+                intval($e->getCode()),
                 $e
             );
         }
@@ -71,7 +71,7 @@ class Factory
         } catch (YamlParseException $e) {
             throw new ConfigException(
                 "unable to decode yaml data",
-                $e->getCode(),
+                intval($e->getCode()),
                 $e
             );
         }
@@ -117,7 +117,7 @@ class Factory
         try {
             $fileContent = $filesystem->read($file);
         } catch (FilesystemException | UnableToReadFile $e) {
-            throw new ConfigException("unable to read data from configuration file '".$file."'", $e->getCode(), $e);
+            throw new ConfigException("unable to read data from configuration file '".$file."'", intval($e->getCode()), $e);
         }
 
         return $fileContent;

--- a/src/DumpData/FromMysqlDump.php
+++ b/src/DumpData/FromMysqlDump.php
@@ -40,7 +40,11 @@ class FromMysqlDump
         try {
             $fileContent = $filesystem->read($dumpFile);
         } catch (FilesystemException | UnableToReadFile $e) {
-            throw new DumpDataException("unable to read contents of file '".$dumpFile."'", $e->getCode(), $e);
+            throw new DumpDataException(
+                "unable to read contents of file '".$dumpFile."'",
+                intval($e->getCode()),
+                $e
+            );
         }
 
         $fileContent = explode("\n", $fileContent);

--- a/src/QueryValidator.php
+++ b/src/QueryValidator.php
@@ -43,7 +43,7 @@ final class QueryValidator
         } catch (\Throwable $t) {
             throw new \RuntimeException(
                 $t->getMessage(),
-                (int) $t->getCode(),
+                intval($t->getCode()),
                 $t
             );
         }

--- a/src/Tester/TestFile.php
+++ b/src/Tester/TestFile.php
@@ -72,7 +72,11 @@ class TestFile implements TestFileInterface
             try {
                 $fileContent = $this->filesystem->read($this->file);
             } catch (FilesystemException | UnableToReadFile $e) {
-                throw new TestFileException("unable to read contents of file '".$this->file."'", $e->getCode(), $e);
+                throw new TestFileException(
+                    "unable to read contents of file '".$this->file."'",
+                    intval($e->getCode()),
+                    $e
+                );
             }
 
             $ast = $parser->parse($fileContent);
@@ -85,13 +89,13 @@ class TestFile implements TestFileInterface
         } catch (PhpParserError $error) {
             throw new TestFileException(
                 "Parse error: ".$error->getMessage()." (".$this->file.")",
-                $error->getCode(),
+                intval($error->getCode()),
                 $error
             );
         } catch (\Throwable $t) {
             throw new QueryValidatorException(
                 "unknown error: ".$t->getMessage()." (".$this->file.")",
-                $t->getCode(),
+                intval($t->getCode()),
                 $t
             );
         }//end try
@@ -104,7 +108,7 @@ class TestFile implements TestFileInterface
         } catch (\Throwable $t) {
             throw new QueryValidatorException(
                 "error: ".$t->getMessage()." (".$this->file.")",
-                $t->getCode(),
+                intval($t->getCode()),
                 $t
             );
         }

--- a/src/Tester/Tester.php
+++ b/src/Tester/Tester.php
@@ -83,7 +83,7 @@ class Tester implements TesterInterface
         } catch (TestFileException $e) {
             throw new TestFileException(
                 "unable to validate file '".$file."'",
-                $e->getCode(),
+                intval($e->getCode()),
                 $e
             );
         }//end try


### PR DESCRIPTION
as codes returned by `getCode()` may be `int` or `string` be codes passed into an exception must be an `int` we convert those to an `int`