### PR TITLE
remove unnecessary null coalescing operator

### DIFF
--- a/src/Tester/PhpNodeVisitor.php
+++ b/src/Tester/PhpNodeVisitor.php
@@ -76,7 +76,7 @@ class PhpNodeVisitor extends NodeVisitorAbstract
             $query,
             $parameters,
             $this->filename,
-            $node->name->getLine() ?? 0
+            $node->name->getLine()
         );
 
         return null;


### PR DESCRIPTION
as getLine() cannot return `null`, the null coalescing operator is useless at this place